### PR TITLE
Add releaseName and releaseId as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ module.exports = {
 }
 ```
 
+If you're using `releaseName` and `releaseId`, make sure one or both are unique per build and
+that you use the [`newrelic.addRelease`](https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-release) method in your code to identify the release.
+
 ## Customize
 
 | Property       | Type           | Description  |
@@ -41,3 +44,5 @@ module.exports = {
 | staticAssetUrlBuilder | function | A function for building the production url your js file is built from.  Will be called for every javascript file with four arguments: staticAssetUrl, the public path from your webpack config, the filename, and the [webpack stats instance](https://github.com/webpack/webpack/blob/master/lib/Stats.js).  Defaults to `${removeLastCharIfSlash(url)}${removeLastCharIfSlash(publicPath)}/${file}` |
 | extensionRegex | regex | a regex used to find js files. Defaults to `/\.js$/` |
 | noop | boolean | control boolean that decides whether or not to run the plugin. Set to true for builds where you don't want to upload assets to new relic. |
+| releaseName | string | [Optional] unique identifier for the release name |
+| releaseId | string | [Optional] unique version for the release identifier |

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 "use strict";
-const {publishSourcemap} = require('@newrelic/publish-sourcemap');
 const uploadSourceMap = require('./src/uploadSourceMap');
 const staticAssetUrlBuilder = require('./src/staticAssetUrlBuilder');
 const enforceExists = require('./src/enforceExists');
@@ -15,6 +14,8 @@ class NewRelicPlugin {
         this.staticAssetUrl = enforceExists(options, 'staticAssetUrl');
         this.staticAssetUrlBuilder = options.staticAssetUrlBuilder || staticAssetUrlBuilder;
         this.extensionRegex = options.extensionRegex || /\.js$/;
+        this.releaseName = options.releaseName || null;
+        this.releaseId = options.releaseId || null;
     }
     apply(compiler) {
         return compiler.plugin('done', (stats) => {
@@ -28,6 +29,8 @@ class NewRelicPlugin {
                     publicPath: stats.compilation.outputOptions.publicPath,
                     nrAdminKey: this.nrAdminKey,
                     applicationId: this.applicationId,
+                    releaseName: this.releaseName,
+                    releaseId: this.releaseId,
                     stats
                 }))
             ).then((values) => {

--- a/src/uploadSourceMap.js
+++ b/src/uploadSourceMap.js
@@ -10,6 +10,8 @@ module.exports = opts => item => {
         applicationId,
         nrAdminKey,
         url,
+        releaseName,
+        releaseId,
         stats
     } = opts;
 
@@ -29,7 +31,9 @@ module.exports = opts => item => {
             sourcemapPath: mapFile.existsAt,
             javascriptUrl,
             applicationId,
-            nrAdminKey
+            nrAdminKey,
+            releaseName,
+            releaseId
         }, (err) => {
             if (err) {
                 reject(err);


### PR DESCRIPTION
This pull request add the ability to submit a release name and release id for the source maps. New Relic uses this information to properly associate errors to their code location.