### PR TITLE
Update webpack hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class NewRelicPlugin {
         this.errorCallback = options.errorCallback || this._getDefaultErrorCallback();
     }
     apply(compiler) {
-        return compiler.plugin('done', (stats) => {
+        return compiler.hooks.done.tap('new-relic-source-map-webpack-plugin', stats => {
             return Promise.all(
                 Object.keys(stats.compilation.assets)
                 .filter(item => this.extensionRegex.test(item))

--- a/index.js
+++ b/index.js
@@ -34,7 +34,14 @@ class NewRelicPlugin {
                     releaseId: this.releaseId,
                     stats
                 }))
-            ).then((values) => {
+            ).then(values => values.filter(value => typeof value !== 'undefined')
+            ).then(values => {
+              values.length === 0 &&
+                this.errorCallback(
+                  'No sourcemaps were found. Check if sourcemaps are enabled: https://webpack.js.org/configuration/devtool/'
+                );
+              return values;
+            }).then((values) => {
                 values.forEach(v => console.log(`sourceMap for ${v} uploaded to newrelic`));
             }).catch((err) => {
                 this.errorCallback(err);

--- a/index.js
+++ b/index.js
@@ -34,14 +34,7 @@ class NewRelicPlugin {
                     releaseId: this.releaseId,
                     stats
                 }))
-            ).then(values => values.filter(value => typeof value !== 'undefined')
-            ).then(values => {
-              values.length === 0 &&
-                this.errorCallback(
-                  'No sourcemaps were found. Check if sourcemaps are enabled: https://webpack.js.org/configuration/devtool/'
-                );
-              return values;
-            }).then((values) => {
+            ).then((values) => {
                 values.forEach(v => console.log(`sourceMap for ${v} uploaded to newrelic`));
             }).catch((err) => {
                 this.errorCallback(err);

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class NewRelicPlugin {
         this.errorCallback = options.errorCallback || this._getDefaultErrorCallback();
     }
     apply(compiler) {
-        return compiler.hooks.done.tap('new-relic-source-map-webpack-plugin', stats => {
+        return compiler.plugin('done', (stats) => {
             return Promise.all(
                 Object.keys(stats.compilation.assets)
                 .filter(item => this.extensionRegex.test(item))


### PR DESCRIPTION
Currently for new webpack setup it gives this warning every time you use plugin hook:
(node:63533) DeprecationWarning: Tapable.plugin is deprecated. Use new API on .hooks instead

This pull request refactors hook so it could use new webpack plugin api